### PR TITLE
Update library to match the current nightly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-build:
+build: src/csv/lib.rs
 	mkdir -p build
 	rustc --out-dir build -O src/csv/lib.rs
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,20 @@
 This parser is a rewrite, different from the original [rust-csv](https://github.com/brson/rust-csv), because the previous project used an old syntax. For a failed attempt to update it to current Rust, see [rust-csv-legacy](https://github.com/Geal/rust-csv-legacy)
 ```Rust
     use csv;
-    use std::io::mem::Memreader;
+    use std::io::MemReader;
 
-    let s = ~"a;b;c;d\r\ne;f;g;h";
-    let mut parser = csv.init(~MemReader::new(s.into_bytes()));
+    fn main() {
+      let s = "a;b;c;d\r\ne;f;g;h";
 
-    //default delimitor is ','
-    parser.delim(';');
+      let reader = MemReader::new(Vec::from_slice(s.as_bytes()));
+      let mut parser = csv::init(reader);
 
-    for row in parser {
-      println!("first element is: {}", row[0]);
+      //default delimitor is ','
+      parser.delim(';');
+
+      for row in parser {
+        println!("first element is: {}", row.get(0));
+      }
     }
 ```
 

--- a/src/csv/lib.rs
+++ b/src/csv/lib.rs
@@ -103,18 +103,8 @@ impl<'a, R: Reader> Parser<'a, R> {
     row
   }
 
-  fn extract_last_row(&mut self) -> Row {
-    self.row.push(str::from_chars(self.acc.as_slice()));
-    self.acc.clear();
-    self.extract_row()
-  }
-
   pub fn delim(&mut self, delim:char) {
     self.delim = delim;
-  }
-
-  fn state(&self) -> State {
-    self.state
   }
 }
 

--- a/src/csv/lib.rs
+++ b/src/csv/lib.rs
@@ -98,9 +98,9 @@ impl<R: Reader> Parser<R> {
   }
 
   fn extract_row(&mut self) -> Row {
-    let row = self.row.clone();
-    self.row.clear();
-    row
+    use std::mem::replace;
+
+    replace(&mut self.row, Vec::new())
   }
 
   pub fn delim(&mut self, delim:char) {

--- a/src/csv/lib.rs
+++ b/src/csv/lib.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::str;
 use std::iter::Iterator;
 
-type Row = ~[~str];
+type Row = Vec<~str>;
 
 enum State {
   Continue,
@@ -18,8 +18,8 @@ pub struct Parser<'a, R> {
   count: uint,
   readlen: uint,
   delim: char,
-  buffer: ~[char],
-  acc: ~[char],
+  buffer: Vec<char>,
+  acc: Vec<char>,
   row: Row,
   reader: &'a mut R,
   state: State
@@ -32,9 +32,9 @@ pub fn init<'a, R: io::Reader>(reader: &'a mut R) -> ~Parser<'a, R> {
     count: 0,
     readlen: 1024,
     delim: ',',
-    buffer: ~[],
-    acc: ~[],
-    row: ~[],
+    buffer: vec!(),
+    acc: vec!(),
+    row: vec!(),
     reader: reader,
     state: Continue
   }
@@ -74,7 +74,7 @@ impl<'a, R: Reader> Parser<'a, R> {
 
   fn parse_char(&mut self, c: char) -> State {
     if c == self.delim {
-        self.row.push(str::from_chars(self.acc));
+        self.row.push(str::from_chars(self.acc.as_slice()));
         self.acc.clear();
         return Continue
     }
@@ -82,14 +82,14 @@ impl<'a, R: Reader> Parser<'a, R> {
     match c {
       '\r' => Continue,
       '\n' => {
-        self.row.push(str::from_chars(self.acc));
+        self.row.push(str::from_chars(self.acc.as_slice()));
         self.acc.clear();
         EOL
       },
       _    => {
         self.acc.push(c);
         if self.buffer.len() == 0 {
-          self.row.push(str::from_chars(self.acc));
+          self.row.push(str::from_chars(self.acc.as_slice()));
           self.acc.clear();
         }
         Continue
@@ -104,7 +104,7 @@ impl<'a, R: Reader> Parser<'a, R> {
   }
 
   fn extract_last_row(&mut self) -> Row {
-    self.row.push(str::from_chars(self.acc));
+    self.row.push(str::from_chars(self.acc.as_slice()));
     self.acc.clear();
     self.extract_row()
   }

--- a/src/csv/lib.rs
+++ b/src/csv/lib.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::str;
 use std::iter::Iterator;
 
-type Row = Vec<~str>;
+pub type Row = Vec<~str>;
 
 enum State {
   Continue,
@@ -120,35 +120,30 @@ impl<'a, R: Reader> Parser<'a, R> {
 
 impl<'a, R: Reader> Iterator<Row> for Parser<'a, R> {
   fn next(&mut self) -> Option<Row> {
-    match self.state {
-      _   => {
-        while true {
-          match self.parse_next_char() {
-            EOL => {
-              let row = self.extract_row();
-              if row.len() > 0 {
-                self.state = Continue;
-                return Some(row);
-              } else {
-                self.state = EOL;
-                return None;
-              }
-            }
-            Continue => (),
-            Wait => {
-              self.state = Wait;
-              let row = self.extract_row();
-              if row.len() > 0 {
-                return Some(row);
-              }  else {
-                return None
-              }
-            }
+    loop {
+      match self.parse_next_char() {
+        EOL => {
+          let row = self.extract_row();
+          if row.len() > 0 {
+            self.state = Continue;
+            return Some(row);
+          } else {
+            self.state = EOL;
+            return None;
+          }
+        }
+        Continue => (),
+        Wait => {
+          self.state = Wait;
+          let row = self.extract_row();
+          if row.len() > 0 {
+            return Some(row);
+          }  else {
+            return None
           }
         }
       }
     }
-    None
   }
 }
 

--- a/src/csv/lib.rs
+++ b/src/csv/lib.rs
@@ -27,9 +27,8 @@ pub struct Parser<'a, R> {
 }
 
 
-pub fn init<'a, R: io::Reader>(reader: &'a mut R) -> ~Parser<'a, R> {
-
-  ~Parser {
+pub fn init<'a, R: io::Reader>(reader: &'a mut R) -> Parser<'a, R> {
+  Parser {
     count: 0,
     readlen: 1024,
     delim: ',',

--- a/src/csv/lib.rs
+++ b/src/csv/lib.rs
@@ -3,6 +3,9 @@
 #![desc = "CSV parser"]
 #![license = "MIT"]
 
+#![feature(phase)]
+#[phase(syntax, link)] extern crate log;
+
 use std::io;
 use std::str;
 use std::iter::Iterator;
@@ -47,14 +50,14 @@ impl<R: Reader> Parser<R> {
       let mut bytes = [0, .. 1024];
       let optnbread = self.reader.read(bytes);
       if bytes.len() == 0 {
-        println!("0 bytes read");
+        debug!("0 bytes read");
         return Wait
       }
 
       match optnbread {
-        Err(e)     => { println!("opntbread error: {}", e); return Wait},
+        Err(e)     => { debug!("opntbread error: {}", e); return Wait},
         Ok(nb)     => {
-          println!("optnbread {} bytes", nb);
+          debug!("optnbread {} bytes", nb);
           let s  = str::from_utf8(bytes);
           if s.is_some() {
             for el in s.unwrap().slice(0, nb).chars() {
@@ -67,7 +70,7 @@ impl<R: Reader> Parser<R> {
 
     let optc = self.buffer.shift();
     match optc {
-      None    => {println!("optc is none");return Wait},
+      None    => { debug!("optc is none");return Wait},
       Some(c) => return self.parse_char(c)
     }
   }

--- a/src/csv/lib.rs
+++ b/src/csv/lib.rs
@@ -1,3 +1,4 @@
+#![crate_id = "csv"]
 #![crate_type = "lib"]
 #![desc = "CSV parser"]
 #![license = "MIT"]

--- a/src/csv/lib.rs
+++ b/src/csv/lib.rs
@@ -1,6 +1,6 @@
-#[crate_type = "lib"];
-#[desc = "CSV parser"];
-#[license = "MIT"];
+#![crate_type = "lib"]
+#![desc = "CSV parser"]
+#![license = "MIT"]
 
 use std::io;
 use std::str;

--- a/src/csv/lib.rs
+++ b/src/csv/lib.rs
@@ -15,19 +15,19 @@ enum State {
   EOL
 }
 
-pub struct Parser<'a, R> {
+pub struct Parser<R> {
   count: uint,
   readlen: uint,
   delim: char,
   buffer: Vec<char>,
   acc: Vec<char>,
   row: Row,
-  reader: &'a mut R,
+  reader: R,
   state: State
 }
 
 
-pub fn init<'a, R: io::Reader>(reader: &'a mut R) -> Parser<'a, R> {
+pub fn init<R: io::Reader>(reader: R) -> Parser<R> {
   Parser {
     count: 0,
     readlen: 1024,
@@ -40,7 +40,7 @@ pub fn init<'a, R: io::Reader>(reader: &'a mut R) -> Parser<'a, R> {
   }
 }
 
-impl<'a, R: Reader> Parser<'a, R> {
+impl<R: Reader> Parser<R> {
   fn parse_next_char(&mut self) -> State {
     if self.buffer.len() == 0 {
 
@@ -108,7 +108,7 @@ impl<'a, R: Reader> Parser<'a, R> {
   }
 }
 
-impl<'a, R: Reader> Iterator<Row> for Parser<'a, R> {
+impl<R: Reader> Iterator<Row> for Parser<R> {
   fn next(&mut self) -> Option<Row> {
     loop {
       match self.parse_next_char() {

--- a/src/csv/test.rs
+++ b/src/csv/test.rs
@@ -7,37 +7,41 @@ mod lib;
 
 #[test]
 fn init() {
-  let s = ~"a,b,c,d";
+  let s = "a,b,c,d";
   let mut reader = ~BufReader::new(s.as_bytes());
   let mut p = csv::init(reader);
   let optrow = p.next();
-  assert_eq!(optrow.unwrap(), ~[~"a", ~"b", ~"c", ~"d"]);
+  assert_eq!(optrow.unwrap(), owned_string_vec(&["a", "b", "c", "d"]));
   assert!(p.next().is_none());
 }
 
 #[test]
 fn multiline() {
-  let s = ~"a,b,c,d\r\ne,f,g,h";
+  let s = "a,b,c,d\r\ne,f,g,h";
   let mut reader = ~BufReader::new(s.as_bytes());
   let mut p = csv::init(reader);
 
   let optrow = p.next();
-  assert_eq!(optrow.unwrap(), ~[~"a", ~"b", ~"c", ~"d"]);
+  assert_eq!(optrow.unwrap(), owned_string_vec(&["a", "b", "c", "d"]));
   let secoptrow = p.next();
-  assert_eq!(secoptrow.unwrap(), ~[~"e", ~"f", ~"g", ~"h"]);
+  assert_eq!(secoptrow.unwrap(), owned_string_vec(&["e", "f", "g", "h"]));
   assert!(p.next().is_none());
 }
 
 #[test]
 fn delim() {
-  let s = ~"aA ;b;c;d; e\r\nf;g;h; I;j\r\n";
+  let s = "aA ;b;c;d; e\r\nf;g;h; I;j\r\n";
   let mut reader = ~BufReader::new(s.as_bytes());
   let mut p = csv::init(reader);
   p.delim(';');
 
   let optrow = p.next();
-  assert_eq!(optrow.unwrap(), ~[~"aA ", ~"b", ~"c", ~"d", ~" e"]);
+  assert_eq!(optrow.unwrap(), owned_string_vec(&["aA ", "b", "c", "d", " e"]));
   let secoptrow = p.next();
-  assert_eq!(secoptrow.unwrap(), ~[~"f", ~"g", ~"h", ~" I", ~"j"]);
+  assert_eq!(secoptrow.unwrap(), owned_string_vec(&["f", "g", "h", " I", "j"]));
   assert!(p.next().is_none());
+}
+
+fn owned_string_vec(slice: &[&str]) -> Vec<~str> {
+  slice.iter().map(|string| string.to_owned()).collect::<Vec<~str>>()
 }

--- a/src/csv/test.rs
+++ b/src/csv/test.rs
@@ -1,7 +1,7 @@
 use csv = lib;
 
 use std::io;
-use io::BufReader;
+use std::io::BufReader;
 
 mod lib;
 

--- a/src/csv/test.rs
+++ b/src/csv/test.rs
@@ -1,6 +1,5 @@
 use csv = lib;
 
-use std::io;
 use std::io::BufReader;
 
 mod lib;

--- a/src/csv/test.rs
+++ b/src/csv/test.rs
@@ -1,8 +1,6 @@
-use csv = lib;
+extern crate csv;
 
 use std::io::BufReader;
-
-mod lib;
 
 #[test]
 fn init() {

--- a/src/csv/test.rs
+++ b/src/csv/test.rs
@@ -5,7 +5,7 @@ use std::io::BufReader;
 #[test]
 fn init() {
   let s = "a,b,c,d";
-  let mut reader = ~BufReader::new(s.as_bytes());
+  let reader = BufReader::new(s.as_bytes());
   let mut p = csv::init(reader);
   let optrow = p.next();
   assert_eq!(optrow.unwrap(), owned_string_vec(&["a", "b", "c", "d"]));
@@ -15,7 +15,7 @@ fn init() {
 #[test]
 fn multiline() {
   let s = "a,b,c,d\r\ne,f,g,h";
-  let mut reader = ~BufReader::new(s.as_bytes());
+  let reader = BufReader::new(s.as_bytes());
   let mut p = csv::init(reader);
 
   let optrow = p.next();
@@ -28,7 +28,7 @@ fn multiline() {
 #[test]
 fn delim() {
   let s = "aA ;b;c;d; e\r\nf;g;h; I;j\r\n";
-  let mut reader = ~BufReader::new(s.as_bytes());
+  let reader = BufReader::new(s.as_bytes());
   let mut p = csv::init(reader);
   p.delim(';');
 


### PR DESCRIPTION
Hi! I've made a few changes to make rust-csv compilable under the current rust-nightly, and to solve a few warnings.

It was mostly about the `~"foo"` removal, and the fact that `~[T]` isn't growable anymore. I also removed a couple functions that were dead code, and some unnecessary uses of `~` (which is currently being discouraged unless necessary).

If you feel this is too big, or that it touches on too many different things, I can split it up
